### PR TITLE
feat: Allow to import customized test file into the screenshots

### DIFF
--- a/src/tiles.ts
+++ b/src/tiles.ts
@@ -2,7 +2,26 @@ enum TileMatrixIdentifier {
   Nztm2000Quad = 'NZTM2000Quad',
   Google = 'WebMercatorQuad',
 }
-export const DefaultTestTiles = [
+
+interface Location {
+  lat: number;
+  lng: number;
+  z: number;
+  b?: number;
+  p?: number;
+}
+
+export interface TestTile {
+  name: string;
+  tileMatrix: TileMatrixIdentifier;
+  location: Location;
+  tileSet: string;
+  style?: string;
+  terrain?: string;
+  hillshade?: string;
+}
+
+export const DefaultTestTiles: TestTile[] = [
   {
     name: 'health-3857-z5',
     tileMatrix: TileMatrixIdentifier.Google,


### PR DESCRIPTION
#### Description
Now we can run screenshot on a test json file. like.
`[
  {
    "name": "health-3857-z5",
    "tileMatrix": "WebMercatorQuad",
    "location": { "lat": -41.8899962, "lng": 174.0492437, "z": 5 },
    "tileSet": "health"
  }
]
`

#### Intention
*Why is this change being made? What implications or other considerations are there?*



#### Checklist
*If not applicable, provide explanation of why.*
- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
