### PR TITLE
feat: Add screenshot test into CI and fix the health test for NZTM2000Quad. BM-1087

### DIFF
--- a/.github/workflows/screenshot.yml
+++ b/.github/workflows/screenshot.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: (Screenshot) Screenshot Pull Request Changes
         run: |
-          ./bms.mjs --url https://basemaps.linz.govt.nz --output $PWD/.artifacts/visual-snapshots
+          ./bms.mjs --url https://basemaps.linz.govt.nz --output .artifacts/visual-snapshots
 
       - name: Save snapshots
         uses: getsentry/action-visual-snapshot@v2

--- a/.github/workflows/screenshot.yml
+++ b/.github/workflows/screenshot.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: (Screenshot) Screenshot Pull Request Changes
         run: |
-          ./bms.mjs --url https://basemaps.linz.govt.nz/ --output $PWD/.artifacts/visual-snapshots
+          ./bms.mjs --url https://basemaps.linz.govt.nz --output $PWD/.artifacts/visual-snapshots
 
       - name: Save snapshots
         uses: getsentry/action-visual-snapshot@v2

--- a/.github/workflows/screenshot.yml
+++ b/.github/workflows/screenshot.yml
@@ -1,0 +1,52 @@
+name: screenshot
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  screenshot:
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: linz/action-typescript@v3
+
+      - name: (Screenshot) Screenshot Pull Request Changes
+        run: |
+          ./bms.mjs --url https://basemaps.linz.govt.nz/ --output $PWD/.artifacts/visual-snapshots
+
+      - name: Save snapshots
+        uses: getsentry/action-visual-snapshot@v2
+        with:
+          save-only: true
+          snapshot-path: .artifacts/visual-snapshots
+
+  visual-diff:
+    permissions:
+      id-token: write
+      contents: write
+      checks: write
+    needs: [screenshot]
+    name: validate screenshots
+    if: github.ref != 'refs/heads/master' && github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: AWS Configure
+        uses: aws-actions/configure-aws-credentials@v4.0.2
+        with:
+          aws-region: ap-southeast-2
+          mask-aws-account-id: true
+          role-to-assume: ${{ secrets.AWS_ROLE_SCREENSHOT }}
+
+      - name: Diff snapshots
+        id: visual-snapshots-diff
+        uses: blacha/action-visual-snapshot@v2
+        with:
+          storage-prefix: 's3://linz-basemaps-screenshot'
+          storage-url: 'https://d25mfjh9syaxsr.cloudfront.net'

--- a/src/tiles.ts
+++ b/src/tiles.ts
@@ -32,7 +32,7 @@ export const DefaultTestTiles: TestTile[] = [
     name: 'health-2193-z3',
     tileMatrix: TileMatrixIdentifier.Nztm2000Quad,
     location: { lat: -41.8899962, lng: 174.0492437, z: 3 },
-    tileSet: 'aerial',
+    tileSet: 'health',
   },
   {
     name: 'aerial-3857-wellington-urban-z16',


### PR DESCRIPTION
### Motivation

We need fix the health screenshot test to point to the health tileset.
Also, adding the screenshot into ci will be helpful for use to see any screenshot test been updated.

### Modifications
- Fix the tileset for `health-2193-z3`.
- Add a github action to take screenshots. 
### Verification
See the PR workflow outputs.
