### PR TITLE
feat: add screenshot tests for the topo-raster tileset BM-1167

### DIFF
--- a/src/tiles.ts
+++ b/src/tiles.ts
@@ -159,6 +159,7 @@ export const DefaultTestTiles: TestTile[] = [
     hillshade: 'LINZ-Terrain',
   },
   {
+    // verify the absence of black edge artifacts around the imagery's perimeter
     name: 'nz-topo-gridless-maps-2193-nz-250k-z4',
     tileMatrix: TileMatrixIdentifier.Nztm2000Quad,
     location: { lat: -40.7899231, lng: 172.2977984, z: 4 },
@@ -166,20 +167,15 @@ export const DefaultTestTiles: TestTile[] = [
     style: 'topo-raster',
   },
   {
-    name: 'nz-topo-gridless-maps-3857-chatham-island-z10',
+    // verify the location and re-projection of the chatham islands imagery
+    name: 'nz-topo-gridless-maps-3857-chatham-islands-250k-z10',
     tileMatrix: TileMatrixIdentifier.Google,
     location: { lat: -43.9090948, lng: -176.540438, z: 10 },
     tileSet: 'topo-raster',
     style: 'topo-raster',
   },
   {
-    name: 'nz-topo-gridless-maps-3857-wellington-250k-z11',
-    tileMatrix: TileMatrixIdentifier.Google,
-    location: { lat: -41.299807, lng: 174.8041651, z: 11 },
-    tileSet: 'topo-raster',
-    style: 'topo-raster',
-  },
-  {
+    // verify the tileset displays the 50k imagery
     name: 'nz-topo-gridless-maps-3857-wellington-50k-z12',
     tileMatrix: TileMatrixIdentifier.Google,
     location: { lat: -41.299807, lng: 174.8041651, z: 12 },

--- a/src/tiles.ts
+++ b/src/tiles.ts
@@ -158,4 +158,32 @@ export const DefaultTestTiles: TestTile[] = [
     style: 'topolite',
     hillshade: 'LINZ-Terrain',
   },
+  {
+    name: 'nz-topo-gridless-maps-2193-nz-250k-z4',
+    tileMatrix: TileMatrixIdentifier.Nztm2000Quad,
+    location: { lat: -40.7899231, lng: 172.2977984, z: 4 },
+    tileSet: 'topo-raster',
+    style: 'topo-raster',
+  },
+  {
+    name: 'nz-topo-gridless-maps-3857-chatham-island-z10',
+    tileMatrix: TileMatrixIdentifier.Google,
+    location: { lat: -43.9090948, lng: -176.540438, z: 10 },
+    tileSet: 'topo-raster',
+    style: 'topo-raster',
+  },
+  {
+    name: 'nz-topo-gridless-maps-3857-wellington-250k-z11',
+    tileMatrix: TileMatrixIdentifier.Google,
+    location: { lat: -41.299807, lng: 174.8041651, z: 11 },
+    tileSet: 'topo-raster',
+    style: 'topo-raster',
+  },
+  {
+    name: 'nz-topo-gridless-maps-3857-wellington-50k-z12',
+    tileMatrix: TileMatrixIdentifier.Google,
+    location: { lat: -41.299807, lng: 174.8041651, z: 12 },
+    tileSet: 'topo-raster',
+    style: 'topo-raster',
+  },
 ];


### PR DESCRIPTION
### Motivation

As a Basemaps developer, I want screenshot tests that capture changes to the Basemaps [NZ Topo Gridless Maps][basemaps] layer (`topo-raster` tileset). We anticipate refactoring the process that generate the layer's imagery. We will undertake such refactoring efforts when we come to support additional Map Series datasets, such as:

- [New Zealand Outer Islands (NZOI)][nzoi]
- [Pacific Islands (PI)][pi]

Having these tests will help us automatically identify artifact concerns and unanticipated changes that may arise due to changes to the imagery generation process.

### Modifications

This work adds three new screenshot tests:

| `nz-topo-gridless-maps-2193-nz-250k-z4` |
| :--- |
| ![][img1] |
| Verifies the absence of black edge artifacts around the imagery's perimeter [[1]]. |

| `nz-topo-gridless-maps-3857-chatham-islands-250k-z10` |
| :--- |
| ![][img2] |
| Verifies the location and re-projection of the Chatham Islands imagery from `EPSG:3793` to `EPSG:3857` [[2]]. |

| `nz-topo-gridless-maps-3857-wellington-50k-z12` |
| :--- |
| ![][img3] |
| Verifies the tileset displays the 50k imagery as defined in the tileset's definition [[3]]. |

### Verification

I have verified the added screenshot tests locally. I used the following commands to install the required dependencies and compile the source code:

```bash
# install dependencies
npm install

# compile the source code
npm run build
```

I then used the following command to run the screenshot process:

```bash
# run the screenshot process
node build/src/bin.js --url basemaps.linz.govt.nz --output screenshot-folder/
```

The process captures the added screenshot tests and saves them to the output location without issue.

<!-- external links -->

[basemaps]: https://basemaps.linz.govt.nz/?style=topo-raster&i=topo-raster
[nzoi]: https://www.linz.govt.nz/products-services/maps/antarctic-pacific-and-nz-offshore-islands-maps/new-zealand-offshore-islands-maps
[pi]: https://www.linz.govt.nz/products-services/maps/antarctic-pacific-and-nz-offshore-islands-maps/pacific-region-maps

[1]: https://toitutewhenua.atlassian.net/browse/BM-1146
[2]: https://toitutewhenua.atlassian.net/browse/BM-1116
[3]: https://github.com/linz/basemaps-config/blob/master/config/tileset/topo-raster.json

[img1]: https://github.com/user-attachments/assets/ccf92b04-75c7-456f-b0fe-d57214f05112
[img2]: https://github.com/user-attachments/assets/e6fa65ac-2a9e-4181-890c-4ef7ca3a2b60
[img3]: https://github.com/user-attachments/assets/89ba56b3-77f9-4898-aeaa-86bb4206fe9f