### PR TITLE
build: upgrade visual snapshot to support new artifacts api

### DIFF
--- a/.github/workflows/screenshot.yml
+++ b/.github/workflows/screenshot.yml
@@ -21,7 +21,7 @@ jobs:
           ./bms.mjs --url https://basemaps.linz.govt.nz --output .artifacts/visual-snapshots
 
       - name: Save snapshots
-        uses: getsentry/action-visual-snapshot@v2
+        uses: blacha/action-visual-snapshot@v2-next
         with:
           save-only: true
           snapshot-path: .artifacts/visual-snapshots
@@ -46,7 +46,7 @@ jobs:
 
       - name: Diff snapshots
         id: visual-snapshots-diff
-        uses: blacha/action-visual-snapshot@v2
+        uses: blacha/action-visual-snapshot@v2-next
         with:
           storage-prefix: 's3://linz-basemaps-screenshot'
           storage-url: 'https://d25mfjh9syaxsr.cloudfront.net'


### PR DESCRIPTION
### Motivation

`getsentry/action-visual-snapshot` has been deprecated and archived, it
is no longer supported, github has recently removed support for the
artifacts API it was using to store the images, causing all of these
actions to fail.

### Modifications

Fork the github action and update it to support the newer github actions
artifacts API.

this is a temporary fix with the intention to replace this github action
with another more supported action in the near term.

### Verification

Checking to see if the build succeeds after this is merged.