### PR TITLE
build: Switch back to linz/action-visual-snapshot. BM-1322

### DIFF
--- a/.github/workflows/screenshot.yml
+++ b/.github/workflows/screenshot.yml
@@ -21,7 +21,7 @@ jobs:
           ./bms.mjs --url https://basemaps.linz.govt.nz --output .artifacts/visual-snapshots
 
       - name: Save snapshots
-        uses: linz/action-visual-snapshot@v2-next
+        uses: linz/action-visual-snapshot@v2
         with:
           save-only: true
           snapshot-path: .artifacts/visual-snapshots
@@ -46,7 +46,7 @@ jobs:
 
       - name: Diff snapshots
         id: visual-snapshots-diff
-        uses: linz/action-visual-snapshot@v2-next
+        uses: linz/action-visual-snapshot@v2
         with:
           storage-prefix: 's3://linz-basemaps-screenshot'
           storage-url: 'https://d25mfjh9syaxsr.cloudfront.net'

--- a/.github/workflows/screenshot.yml
+++ b/.github/workflows/screenshot.yml
@@ -21,7 +21,7 @@ jobs:
           ./bms.mjs --url https://basemaps.linz.govt.nz --output .artifacts/visual-snapshots
 
       - name: Save snapshots
-        uses: linz/action-visual-snapshot@v2
+        uses: linz/action-visual-snapshot@v2.1
         with:
           save-only: true
           snapshot-path: .artifacts/visual-snapshots

--- a/.github/workflows/screenshot.yml
+++ b/.github/workflows/screenshot.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Diff snapshots
         id: visual-snapshots-diff
-        uses: linz/action-visual-snapshot@v2
+        uses: linz/action-visual-snapshot@v2.1
         with:
           storage-prefix: 's3://linz-basemaps-screenshot'
           storage-url: 'https://d25mfjh9syaxsr.cloudfront.net'

--- a/.github/workflows/screenshot.yml
+++ b/.github/workflows/screenshot.yml
@@ -21,7 +21,7 @@ jobs:
           ./bms.mjs --url https://basemaps.linz.govt.nz --output .artifacts/visual-snapshots
 
       - name: Save snapshots
-        uses: blacha/action-visual-snapshot@v2-next
+        uses: linz/action-visual-snapshot@v2-next
         with:
           save-only: true
           snapshot-path: .artifacts/visual-snapshots
@@ -46,7 +46,7 @@ jobs:
 
       - name: Diff snapshots
         id: visual-snapshots-diff
-        uses: blacha/action-visual-snapshot@v2-next
+        uses: linz/action-visual-snapshot@v2-next
         with:
           storage-prefix: 's3://linz-basemaps-screenshot'
           storage-url: 'https://d25mfjh9syaxsr.cloudfront.net'


### PR DESCRIPTION
### Motivation

Security team asked us to remove third party github actions. I have update the https://github.com/linz/action-visual-snapshot with the fixes of https://github.com/blacha/action-visual-snapshot. So that we can switch back to use linz actions.

### Modifications

<!-- TODO: Say what changes you made. -->

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->
